### PR TITLE
feat: methods for removing single overrides

### DIFF
--- a/packages/js-local-overrides/src/LocalOverrideAdapter.ts
+++ b/packages/js-local-overrides/src/LocalOverrideAdapter.ts
@@ -32,6 +32,10 @@ export class LocalOverrideAdapter implements OverrideAdapter {
     this._overrides.gate[name] = value;
   }
 
+  removeGateOverride(name: string): void {
+    delete this._overrides.gate[name];
+  }
+
   getGateOverride(
     current: FeatureGate,
     _user: StatsigUser,
@@ -52,6 +56,10 @@ export class LocalOverrideAdapter implements OverrideAdapter {
     this._overrides.dynamicConfig[name] = value;
   }
 
+  removeDynamicConfigOverride(name: string): void {
+    delete this._overrides.dynamicConfig[name];
+  }
+
   getDynamicConfigOverride(
     current: DynamicConfig,
     _user: StatsigUser,
@@ -63,6 +71,10 @@ export class LocalOverrideAdapter implements OverrideAdapter {
     this._overrides.experiment[name] = value;
   }
 
+  removeExperimentOverride(name: string): void {
+    delete this._overrides.experiment[name];
+  }
+
   getExperimentOverride(
     current: Experiment,
     _user: StatsigUser,
@@ -72,6 +84,10 @@ export class LocalOverrideAdapter implements OverrideAdapter {
 
   overrideLayer(name: string, value: Record<string, unknown>): void {
     this._overrides.layer[name] = value;
+  }
+
+  removeLayerOverride(name: string): void {
+    delete this._overrides.layer[name];
   }
 
   getAllOverrides(): OverrideStore {

--- a/packages/js-local-overrides/src/__tests__/LocalOverrides.test.ts
+++ b/packages/js-local-overrides/src/__tests__/LocalOverrides.test.ts
@@ -73,4 +73,46 @@ describe('Local Overrides', () => {
       layer: {},
     });
   });
+  it('returns removes single override', () => {
+    const gateB = _makeFeatureGate('b_gate', { reason: '' }, null);
+    const dynamicConfigB = _makeDynamicConfig('b_config', { reason: '' }, null);
+    const experimentB = _makeExperiment('b_experiment', { reason: '' }, null);
+    const layerB = _makeLayer('b_layer', { reason: '' }, null);
+
+    provider.overrideGate(gate.name, true);
+    provider.overrideDynamicConfig(dynamicConfig.name, { dc: 'value' });
+    provider.overrideExperiment(experiment.name, { exp: 'value' });
+    provider.overrideLayer(layer.name, { layer_key: 'value' });
+
+    provider.overrideGate(gateB.name, true);
+    provider.overrideDynamicConfig(dynamicConfigB.name, { dc: 'value' });
+    provider.overrideExperiment(experimentB.name, { exp: 'value' });
+    provider.overrideLayer(layerB.name, { layer_key: 'value' });
+
+    provider.removeGateOverride(gate.name);
+    provider.removeDynamicConfigOverride(dynamicConfig.name);
+    provider.removeExperimentOverride(experiment.name);
+    provider.removeLayerOverride(layer.name);
+
+    expect(provider.getAllOverrides()).toEqual({
+      dynamicConfig: {
+        b_config: {
+          dc: 'value',
+        },
+      },
+      experiment: {
+        b_experiment: {
+          exp: 'value',
+        },
+      },
+      gate: {
+        b_gate: true,
+      },
+      layer: {
+        b_layer: {
+          layer_key: 'value',
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
There have been no contributions to this repo yet, so I don't know if contributing from the outside is even an option. Let me know.

Our team wants to migrate to the new SDK, but since it's pretty fresh, some helpful things are missing from the old one. This 
PR adds methods for removing a single override based on its name. 


