### PR TITLE
fix(react-core,expo-bindings): a networking error occurred during POST request

### DIFF
--- a/packages/react-native-core/src/RNSetup.ts
+++ b/packages/react-native-core/src/RNSetup.ts
@@ -24,12 +24,10 @@ export function _setupStatsigForReactNative(
     options.storageProvider = _createPreloadedAsyncStorage();
   }
 
-  if (type === 'rn') {
-    _applyReactNativeNetworkFix(options);
-  }
+  _applyNetworkFix(options);
 }
 
-function _applyReactNativeNetworkFix(options: AnyStatsigOptions) {
+function _applyNetworkFix(options: AnyStatsigOptions) {
   if (options.networkConfig?.networkOverrideFunc != null) {
     return;
   }


### PR DESCRIPTION
This PR addresses an issue reported by @spsaucier regarding networking errors in Expo when initializing Statsig. The fix leverages the existing `_applyReactNativeNetworkFix` function, which already contained the appropriate logic for handling network requests. By adjusting the setup logic, this fix extends support to Expo environments without introducing new logic.

- **Renamed `_applyReactNativeNetworkFix` to `_applyNetworkFix`** to reflect its broader applicability beyond React Native.
- **Removed the conditional check for `type === 'rn'`** in `_setupStatsigForReactNative` to ensure the network fix is applied to both React Native and Expo environments.

The networking issue stemmed from the conditional logic that restricted the network fix to React Native only. Since the logic in `_applyReactNativeNetworkFix` was already compatible with Expo, removing the condition effectively resolved the problem without additional changes.

### Testing
- Confirmed that Statsig initializes successfully in both React Native and Expo environments.
- Verified that network requests function correctly with the updated logic.
- Ensured all tests continue to pass without regressions.

**Closes:** #19

