### PR TITLE
[AXON-293] Add _isServerEnv override for VSCODE extensions

### DIFF
--- a/packages/client-core/src/EventLogger.ts
+++ b/packages/client-core/src/EventLogger.ts
@@ -119,7 +119,8 @@ export class EventLogger {
   }
 
   start(): void {
-    if (_isServerEnv()) {
+    const override = this._options?.overrideServerEnv
+    if (_isServerEnv() && !override) {
       return; // do not run in server environments
     }
 
@@ -182,7 +183,10 @@ export class EventLogger {
   }
 
   private _shouldLogEvent(event: StatsigEventInternal): boolean {
-    if (_isServerEnv()) {
+
+    const override = this._options?.overrideServerEnv;
+
+    if (_isServerEnv() && !override) {
       return false; // do not run in server environments
     }
 

--- a/packages/client-core/src/StatsigClientBase.ts
+++ b/packages/client-core/src/StatsigClientBase.ts
@@ -112,7 +112,7 @@ export abstract class StatsigClientBase<
 
     this._primeReadyRipcord();
 
-    _assignGlobalInstance(sdkKey, this as unknown as StatsigClientInterface);
+    _assignGlobalInstance(sdkKey, this as unknown as StatsigClientInterface, this._options.overrideServerEnv);
   }
 
   /**

--- a/packages/client-core/src/StatsigClientBase.ts
+++ b/packages/client-core/src/StatsigClientBase.ts
@@ -281,8 +281,8 @@ export abstract class StatsigClientBase<
   protected abstract _primeReadyRipcord(): void;
 }
 
-function _assignGlobalInstance(sdkKey: string, client: StatsigClientInterface) {
-  if (_isServerEnv()) {
+function _assignGlobalInstance(sdkKey: string, client: StatsigClientInterface, overrideServerEnv?: boolean) {
+  if (_isServerEnv() && !overrideServerEnv) {
     return;
   }
 

--- a/packages/client-core/src/StatsigOptionsCommon.ts
+++ b/packages/client-core/src/StatsigOptionsCommon.ts
@@ -167,6 +167,12 @@ export type StatsigOptionsCommon<NetworkConfig extends NetworkConfigCommon> =
      * default: `false`
      */
     disableEvaluationMemoization?: boolean;
+
+
+    /**
+     * Overrides the blocking of exposure events if you are working in a Node js project
+     */
+    overrideServerEnv?: boolean
   };
 
 export type AnyStatsigOptions = StatsigOptionsCommon<NetworkConfigCommon>;

--- a/packages/js-client/src/StatsigOptions.ts
+++ b/packages/js-client/src/StatsigOptions.ts
@@ -55,10 +55,5 @@ export type StatsigOptions = Flatten<
      * Register various plugins to run along with your StatsigClient (eg SessionReplay or AutoCapture)
      */
     plugins?: StatsigPlugin<StatsigClient>[];
-
-    /**
-     * Overrides the blocking of exposure events if you are working in a Node js project
-     */
-    overrideServerEnv?: boolean
   }
 >;

--- a/packages/js-client/src/StatsigOptions.ts
+++ b/packages/js-client/src/StatsigOptions.ts
@@ -55,5 +55,10 @@ export type StatsigOptions = Flatten<
      * Register various plugins to run along with your StatsigClient (eg SessionReplay or AutoCapture)
      */
     plugins?: StatsigPlugin<StatsigClient>[];
+
+    /**
+     * Overrides the blocking of exposure events if you are working in a Node js project
+     */
+    overrideServerEnv?: boolean
   }
 >;


### PR DESCRIPTION
### What is this change:

- Added the ability to override the `_isServerEnv()` method which blocks our ability to send exposure events

### Why:

- We are working with a VSCODE extension which is a Node js project but we want to use the statsig js client
- We cannot use the node client bc VSCODE extension code is minified and shipped to the user which makes secret sdk-keys vulnerable for exposure

Related to https://github.com/statsig-io/js-client-monorepo/issues/23