### PR TITLE
feat(react-bindings): add legacy client sdk support

### DIFF
--- a/packages/react-bindings/src/__tests__/useStatsigInternalClientFactoryBootstrap.test.tsx
+++ b/packages/react-bindings/src/__tests__/useStatsigInternalClientFactoryBootstrap.test.tsx
@@ -9,13 +9,13 @@ import { useStatsigInternalClientFactoryBootstrap } from '../useStatsigInternalC
 
 function clientFactory() {
   const client = MockRemoteServerEvalClient.create();
-  
+
   // Add dataAdapter mock with both setData and setDataLegacy methods
   client.dataAdapter = {
     setData: jest.fn(),
     setDataLegacy: jest.fn(),
   };
-  
+
   let resolveinitializeAsync: (() => void) | undefined;
   client.initializeAsync.mockReturnValue(
     new Promise<void>((resolve) => {
@@ -51,7 +51,7 @@ const TestComponent = ({
       initialValues: JSON.stringify({ test: 'data' }),
       statsigOptions: null,
       useLegacyClient,
-    }
+    },
   );
 
   return <div data-testid="client-ready">{client ? 'Ready' : 'Not Ready'}</div>;
@@ -82,7 +82,7 @@ describe('useStatsigInternalClientFactoryBootstrap', () => {
 
   it('calls setData when useLegacyClient is false', () => {
     let capturedClient: any = null;
-    
+
     render(
       <TestComponent
         sdkKey="test-sdk-key-standard"
@@ -90,12 +90,12 @@ describe('useStatsigInternalClientFactoryBootstrap', () => {
         onClientCreated={(client) => {
           capturedClient = client;
         }}
-      />
+      />,
     );
 
     expect(capturedClient).not.toBeNull();
     expect(capturedClient.dataAdapter.setData).toHaveBeenCalledWith(
-      JSON.stringify({ test: 'data' })
+      JSON.stringify({ test: 'data' }),
     );
     expect(capturedClient.dataAdapter.setDataLegacy).not.toHaveBeenCalled();
     expect(capturedClient.initializeSync).toHaveBeenCalled();
@@ -103,19 +103,19 @@ describe('useStatsigInternalClientFactoryBootstrap', () => {
 
   it('calls setData when useLegacyClient is not provided (default behavior)', () => {
     let capturedClient: any = null;
-    
+
     render(
       <TestComponent
         sdkKey="test-sdk-key-default"
         onClientCreated={(client) => {
           capturedClient = client;
         }}
-      />
+      />,
     );
 
     expect(capturedClient).not.toBeNull();
     expect(capturedClient.dataAdapter.setData).toHaveBeenCalledWith(
-      JSON.stringify({ test: 'data' })
+      JSON.stringify({ test: 'data' }),
     );
     expect(capturedClient.dataAdapter.setDataLegacy).not.toHaveBeenCalled();
     expect(capturedClient.initializeSync).toHaveBeenCalled();
@@ -123,7 +123,7 @@ describe('useStatsigInternalClientFactoryBootstrap', () => {
 
   it('calls setDataLegacy when useLegacyClient is true', () => {
     let capturedClient: any = null;
-    
+
     render(
       <TestComponent
         sdkKey="test-sdk-key-legacy"
@@ -131,13 +131,13 @@ describe('useStatsigInternalClientFactoryBootstrap', () => {
         onClientCreated={(client) => {
           capturedClient = client;
         }}
-      />
+      />,
     );
 
     expect(capturedClient).not.toBeNull();
     expect(capturedClient.dataAdapter.setDataLegacy).toHaveBeenCalledWith(
       JSON.stringify({ test: 'data' }),
-      { userID: 'test-user' }
+      { userID: 'test-user' },
     );
     expect(capturedClient.dataAdapter.setData).not.toHaveBeenCalled();
     expect(capturedClient.initializeSync).toHaveBeenCalled();

--- a/packages/react-bindings/src/__tests__/useStatsigInternalClientFactoryBootstrap.test.tsx
+++ b/packages/react-bindings/src/__tests__/useStatsigInternalClientFactoryBootstrap.test.tsx
@@ -1,0 +1,145 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { MockRemoteServerEvalClient } from 'statsig-test-helpers';
+
+import { _getStatsigGlobal } from '@statsig/client-core';
+
+import { useStatsigInternalClientFactoryBootstrap } from '../useStatsigInternalClientFactoryBootstrap';
+
+function clientFactory() {
+  const client = MockRemoteServerEvalClient.create();
+  
+  // Add dataAdapter mock with both setData and setDataLegacy methods
+  client.dataAdapter = {
+    setData: jest.fn(),
+    setDataLegacy: jest.fn(),
+  };
+  
+  let resolveinitializeAsync: (() => void) | undefined;
+  client.initializeAsync.mockReturnValue(
+    new Promise<void>((resolve) => {
+      resolveinitializeAsync = resolve;
+    }),
+  );
+  return {
+    client,
+    finishInitializeAsync: () => {
+      resolveinitializeAsync?.();
+    },
+  };
+}
+
+const TestComponent = ({
+  sdkKey,
+  useLegacyClient,
+  onClientCreated,
+}: {
+  sdkKey: string;
+  useLegacyClient?: boolean;
+  onClientCreated?: (client: any) => void;
+}) => {
+  const client = useStatsigInternalClientFactoryBootstrap(
+    (_args) => {
+      const { client } = clientFactory();
+      onClientCreated?.(client);
+      return client;
+    },
+    {
+      sdkKey,
+      initialUser: { userID: 'test-user' },
+      initialValues: JSON.stringify({ test: 'data' }),
+      statsigOptions: null,
+      useLegacyClient,
+    }
+  );
+
+  return <div data-testid="client-ready">{client ? 'Ready' : 'Not Ready'}</div>;
+};
+
+describe('useStatsigInternalClientFactoryBootstrap', () => {
+  const readySdkKey = 'client-key-ready';
+
+  beforeAll(() => {
+    // Create mock SDK that's ready
+    const { client } = clientFactory();
+    (client.loadingStatus as any) = 'Ready';
+
+    // Add this client to Statsig Global with the sdkKey
+    const global = _getStatsigGlobal();
+    const instances = global.instances ?? {};
+    instances[readySdkKey] = client;
+    global.instances = instances;
+  });
+
+  afterAll(() => {
+    delete _getStatsigGlobal().instances;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls setData when useLegacyClient is false', () => {
+    let capturedClient: any = null;
+    
+    render(
+      <TestComponent
+        sdkKey="test-sdk-key-standard"
+        useLegacyClient={false}
+        onClientCreated={(client) => {
+          capturedClient = client;
+        }}
+      />
+    );
+
+    expect(capturedClient).not.toBeNull();
+    expect(capturedClient.dataAdapter.setData).toHaveBeenCalledWith(
+      JSON.stringify({ test: 'data' })
+    );
+    expect(capturedClient.dataAdapter.setDataLegacy).not.toHaveBeenCalled();
+    expect(capturedClient.initializeSync).toHaveBeenCalled();
+  });
+
+  it('calls setData when useLegacyClient is not provided (default behavior)', () => {
+    let capturedClient: any = null;
+    
+    render(
+      <TestComponent
+        sdkKey="test-sdk-key-default"
+        onClientCreated={(client) => {
+          capturedClient = client;
+        }}
+      />
+    );
+
+    expect(capturedClient).not.toBeNull();
+    expect(capturedClient.dataAdapter.setData).toHaveBeenCalledWith(
+      JSON.stringify({ test: 'data' })
+    );
+    expect(capturedClient.dataAdapter.setDataLegacy).not.toHaveBeenCalled();
+    expect(capturedClient.initializeSync).toHaveBeenCalled();
+  });
+
+  it('calls setDataLegacy when useLegacyClient is true', () => {
+    let capturedClient: any = null;
+    
+    render(
+      <TestComponent
+        sdkKey="test-sdk-key-legacy"
+        useLegacyClient={true}
+        onClientCreated={(client) => {
+          capturedClient = client;
+        }}
+      />
+    );
+
+    expect(capturedClient).not.toBeNull();
+    expect(capturedClient.dataAdapter.setDataLegacy).toHaveBeenCalledWith(
+      JSON.stringify({ test: 'data' }),
+      { userID: 'test-user' }
+    );
+    expect(capturedClient.dataAdapter.setData).not.toHaveBeenCalled();
+    expect(capturedClient.initializeSync).toHaveBeenCalled();
+  });
+});

--- a/packages/react-bindings/src/useClientBootstrapInit.ts
+++ b/packages/react-bindings/src/useClientBootstrapInit.ts
@@ -8,6 +8,7 @@ export function useClientBootstrapInit(
   initialUser: StatsigUser,
   initialValues: string,
   statsigOptions: StatsigOptions | null = null,
+  useLegacyClient?: boolean,
 ): StatsigClient {
   return useStatsigInternalClientFactoryBootstrap(
     (args) =>
@@ -17,6 +18,7 @@ export function useClientBootstrapInit(
       initialUser,
       initialValues,
       statsigOptions,
+      useLegacyClient,
     },
   );
 }

--- a/packages/react-bindings/src/useStatsigInternalClientFactoryBootstrap.ts
+++ b/packages/react-bindings/src/useStatsigInternalClientFactoryBootstrap.ts
@@ -8,6 +8,7 @@ type FactoryArgs = {
   initialUser: StatsigUser;
   initialValues: string;
   statsigOptions: StatsigOptions | null;
+  useLegacyClient?: boolean;
 };
 
 export function useStatsigInternalClientFactoryBootstrap<
@@ -23,7 +24,12 @@ export function useStatsigInternalClientFactoryBootstrap<
     const inst = factory(args);
     clientRef.current = inst;
 
-    inst.dataAdapter.setData(args.initialValues);
+    if (args.useLegacyClient) {
+      inst.dataAdapter.setDataLegacy(args.initialValues, args.initialUser);
+    } else {
+      inst.dataAdapter.setData(args.initialValues);
+    }
+
     inst.initializeSync();
 
     return inst;


### PR DESCRIPTION
### Add Legacy Client Support to React Bindings SDK

**Problem:**

Currently, it's not possible to use the legacy client with the React Bindings SDK because the bootstrap initialisation always calls dataAdapter.setData(). However, Cloudflare integration requires using dataAdapter.setDataLegacy() method from the legacy Node SDK.

**Solution:**

- Added an optional useLegacyClient parameter to useClientBootstrapInit
- Modified useStatsigInternalClientFactoryBootstrap to conditionally call setDataLegacy when the legacy client flag is enabled
- When using legacy client, passes both initialValues and initialUser to setDataLegacy as required by the legacy API
- Maintains backward compatibility by defaulting to the standard setData behavior

**Context:**

Per discussion with Statsig: *"I chatted with our SDK PM and they're still figuring out what the long-term plan will be for a server SDK on cloudflare. If they can get the new SDK running there it might be that, but for now the 'Legacy' Node SDK will be fully supported for cases like that, until we have a new solution."*

This change enables developers using Cloudflare deployments to leverage the React bindings with the legacy Node SDK until a permanent solution is available.

**Testing:**

- [ ]  Verify standard client behavior remains unchanged
- [ ]  Test legacy client integration with Cloudflare environment
- [ ]  Confirm setDataLegacy is called with correct parameters when useLegacyClient: true