### PR TITLE
Fix EventLogger process hangs in Node.js

### DIFF
--- a/packages/client-core/src/EventLogger.ts
+++ b/packages/client-core/src/EventLogger.ts
@@ -158,6 +158,22 @@ export class EventLogger {
 
     this._retryFailedLogs(RetryFailedLogsTrigger.Startup);
     this._startBackgroundFlushInterval();
+
+    const flushIntervalId = this._flushIntervalId;
+    if (
+      isServerEnv &&
+      flushIntervalId != null &&
+      typeof flushIntervalId === 'object'
+    ) {
+      // `Timeout::unref` is a Node.js API that allows the event loop to exit
+      // regardless of this timer being active.
+      //
+      // Flushing pending events on exit isn't implemented because calling `stop` seems to cause other
+      // hangs.
+      //
+      // The consumer can call `stop` manually to flush pending events.
+      (flushIntervalId as unknown as { unref: () => void }).unref();
+    }
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
If the client SDK is used on a server environment enabling event logging causes processes to hang indefintely.

This is due to the `setInterval` call in `EventLogger` stopping Node.js from exiting.

This diff adds a `Timeout::unref` call in the `EventLogger` so processes can exit normally.

Events can be flushed by adding a `beforeExit` hook and handling termination. There might be another similar problem on the network code as trying to flush on a beforeExit hook also causes processes to hang.

[🧵 Slack thread](https://statsigcommunity.slack.com/archives/C01RAKM10TD/p1753838765077879)