### PR TITLE
fix: add Expo 55 support to expo-bindings peer dependencies

### DIFF
--- a/packages/expo-bindings/package.json
+++ b/packages/expo-bindings/package.json
@@ -17,8 +17,8 @@
   "peerDependencies": {
     "react": "^16.6.3 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-native": "0.*",
-    "expo-application": "5.* || 6.* || 7.*",
-    "expo-device": "5.* || 6.* || 7.* || 8.*"
+    "expo-application": "5.* || 6.* || 7.* || 55.*",
+    "expo-device": "5.* || 6.* || 7.* || 8.* || 55.*"
   },
   "type": "commonjs",
   "main": "./src/index.js",


### PR DESCRIPTION
## Summary

- Expo SDK 55 changed its versioning strategy so individual packages now match the SDK major version (e.g. `expo-application@55.0.x`, `expo-device@55.0.x` instead of `7.x`, `8.x`)
- This causes `ERESOLVE` peer dependency failures when installing `@statsig/expo-bindings` in Expo 55 projects
- Widens the `expo-application` and `expo-device` peer dependency ranges to include `55.*`

Closes #45