### PR TITLE
Fix massive performance issue

### DIFF
--- a/packages/on-device-eval-core/src/SpecStore.ts
+++ b/packages/on-device-eval-core/src/SpecStore.ts
@@ -40,7 +40,7 @@ export class SpecStore {
   private _defaultEnvironment: string | null = null;
 
   getValues(): DownloadConfigSpecsResponse | null {
-    return this._rawValues ? _parseResponse(this._rawValues) : null;
+    return this._values;
   }
 
   getSource(): DataSource {


### PR DESCRIPTION
The config is parsed when it's set, it doesn't need to be parsed every single time it's read.  This results in anywhere between 99% and 99.9% reduction in time, based on the config that's being parsed.

Times went from 500ms to 5ms on my Macbook M4 Pro.