### PR TITLE
fix: Angular TGZ with circular dependency

### DIFF
--- a/packages/angular-bindings/src/checkGate.directive.ts
+++ b/packages/angular-bindings/src/checkGate.directive.ts
@@ -8,7 +8,7 @@ import {
 
 import { Log } from '@statsig/client-core';
 
-import { FeatureGateOptions } from './statsig.module';
+import { FeatureGateOptions } from './statsig.providers';
 import { StatsigService } from './statsig.service';
 
 @Directive({

--- a/packages/angular-bindings/src/statsig.module.ts
+++ b/packages/angular-bindings/src/statsig.module.ts
@@ -1,30 +1,12 @@
-import { InjectionToken, NgModule } from '@angular/core';
-
-import {
-  FeatureGateEvaluationOptions,
-  StatsigClient,
-  StatsigOptions,
-  StatsigUser,
-} from '@statsig/js-client';
+import { NgModule } from '@angular/core';
 
 import { CheckGateDirective } from './checkGate.directive';
 
-type WithClient<T extends StatsigClient> = { client: T };
-type WithConfiguration = {
-  sdkKey: string;
-  user: StatsigUser;
-  options?: StatsigOptions;
-};
-
-export type StatsigInitConfig<T extends StatsigClient> =
-  | WithClient<T>
-  | WithConfiguration;
-
-export const STATSIG_INIT_CONFIG = new InjectionToken<
-  StatsigInitConfig<StatsigClient>
->('StatsigProvider');
-
-export type FeatureGateOptions = FeatureGateEvaluationOptions;
+export {
+  FeatureGateOptions,
+  STATSIG_INIT_CONFIG,
+  StatsigInitConfig,
+} from './statsig.providers';
 
 @NgModule({
   declarations: [CheckGateDirective],

--- a/packages/angular-bindings/src/statsig.providers.ts
+++ b/packages/angular-bindings/src/statsig.providers.ts
@@ -1,0 +1,25 @@
+import { InjectionToken } from '@angular/core';
+
+import {
+  FeatureGateEvaluationOptions,
+  StatsigClient,
+  StatsigOptions,
+  StatsigUser,
+} from '@statsig/js-client';
+
+type WithClient<T extends StatsigClient> = { client: T };
+type WithConfiguration = {
+  sdkKey: string;
+  user: StatsigUser;
+  options?: StatsigOptions;
+};
+
+export type StatsigInitConfig<T extends StatsigClient> =
+  | WithClient<T>
+  | WithConfiguration;
+
+export type FeatureGateOptions = FeatureGateEvaluationOptions;
+
+export const STATSIG_INIT_CONFIG = new InjectionToken<
+  StatsigInitConfig<StatsigClient>
+>('StatsigProvider');

--- a/packages/angular-bindings/src/statsig.service.ts
+++ b/packages/angular-bindings/src/statsig.service.ts
@@ -22,7 +22,7 @@ import {
 import { StatsigClient } from '@statsig/js-client';
 
 import { Memoize } from './memoizeDecorator';
-import { STATSIG_INIT_CONFIG, StatsigInitConfig } from './statsig.module';
+import { STATSIG_INIT_CONFIG, StatsigInitConfig } from './statsig.providers';
 
 @Injectable({
   providedIn: 'root',


### PR DESCRIPTION
The source code for angular-bindings has a circular dependency between statsig.module.ts -> checkGate.directive.ts -> statsig.service.ts -> statsig.module.ts. 
Please check out the picture
<img width="2559" height="1292" alt="image" src="https://github.com/user-attachments/assets/ddca9db4-4265-4568-930e-2a19ade4af26" />

1. Module imports a directive 
2. Directive imports service 
3. service uses STATSIG_INIT_CONFIG from module
4. STATSIG_INIT_CONFIG is not yet initialized

The issue shows itself when you try to run tests in other projects which import NPM Package (jest or vitest, it doesn't matter).

<img width="1413" height="346" alt="image" src="https://github.com/user-attachments/assets/d2979881-a55c-4b54-8532-41e6d92f16be" />

Fix: extracted STATSIG_INIT_CONFIG, StatsigInitConfig, and FeatureGateOptions into a new leaf file statsig.providers.ts 

Fix doesn't change any logic but normalizes the flow of importing