### PR TITLE
[codex] Pin GitHub Actions workflow references

### DIFF
--- a/.github/actions/setup-action/action.yml
+++ b/.github/actions/setup-action/action.yml
@@ -2,14 +2,14 @@ name: 'Setup Action'
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
       name: Install pnpm
       with:
         version: 7.32.4
         run_install: false
 
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 20
         cache: 'pnpm'
@@ -19,7 +19,7 @@ runs:
       run: pnpm install --frozen-lockfile
 
     - name: Cache nx cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: .nx/cache
         key: ${{ runner.os }}-nx-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'nx.json', '**/project.json') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: ./.github/actions/setup-action
       - run: pnpm lint
 
@@ -30,23 +30,23 @@ jobs:
     env:
       CI_JOB_NUMBER: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: ./.github/actions/setup-action
       - run: pnpm run build
 
-      - uses: daniel-statsig/size-limit-action@main
+      - uses: daniel-statsig/size-limit-action@8a9389e94961464c6ea137d06d519745dcda163e # main
         if: github.event_name == 'pull_request'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           script: pnpm run size --json
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: './dist/samples/web-minified'
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: 'js-client-monorepo-packages-dist'
           if-no-files-found: error
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: ./.github/actions/setup-action
       - run: |
           pnpm run test --testPathIgnorePatterns=MemoryLeak.test.ts
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: ./.github/actions/setup-action
       - run: pnpm exec nx run next-js-sample-e2e:e2e
 
@@ -84,4 +84,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release_bot.yml
+++ b/.github/workflows/release_bot.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 
-      - uses: statsig-io/statsig-publish-sdk-action@main
+      - uses: statsig-io/statsig-publish-sdk-action@c0740fb8a2d4813522cc09bb8c4e826bb78ce6ab # main
         with:
           kong-private-key: ${{ secrets.KONG_GH_APP_PRIVATE_KEY }}
           npm-token: ${{ secrets.NPM_AUTOMATION_KEY }}

--- a/.github/workflows/release_version_bump.yml
+++ b/.github/workflows/release_version_bump.yml
@@ -61,7 +61,7 @@ jobs:
           done
 
       - name: Checkout Statsig Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: statsig-io/statsig
           ref: main
@@ -69,7 +69,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '23'
 
@@ -101,7 +101,7 @@ jobs:
 
       - name: Commit and create PR
         id: create_pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.ROIM }}
           commit-message: 'Automator: [automated][release] Bump versions for official release ${{ steps.ver_res.outputs.version }}'
@@ -121,7 +121,7 @@ jobs:
 
       - name: Enable auto-merge for PR
         if: steps.create_pr.outputs.pull-request-number != ''
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           token: ${{ secrets.ROIM }}
           pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}

--- a/.github/workflows/repo_admin.yml
+++ b/.github/workflows/repo_admin.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Close Stale Pull Requests
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-stale: 14 # Mark Issues/PRs as stale after 18 days (3 weeks - 7 days)
           days-before-close: 7 # Close stale Issues/PRs after 7 additional days

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Trigger Scheduled Test Runs
         if: github.event.repository.private
-        uses: actions/github-script@v6
+        uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # v6
         with:
           script: |
             const args = {


### PR DESCRIPTION
Pin floating external GitHub Actions workflow refs to immutable SHAs.

Why are we doing this? Please see the rationale doc: https://docs.google.com/document/d/1qOURCNx2zszQ0uWx7Fj5ERu4jpiYjxLVWBWgKa2wTsA/edit?tab=t.0

Did this break you? Please roll back and let hintz@ know
