### PR TITLE
fix(client-core): omit event headers for cross-origin log event urls

### DIFF
--- a/packages/client-core/src/EventSender.ts
+++ b/packages/client-core/src/EventSender.ts
@@ -1,13 +1,13 @@
 import { EventBatch } from './EventBatch';
 import { Log } from './Log';
 import { NetworkParam } from './NetworkConfig';
-import {
+import type {
   NetworkCore,
   RequestArgsWithData,
   RequestFailureInfo,
 } from './NetworkCore';
-import { _getWindowSafe } from './SafeJs';
 import { SDKType } from './SDKType';
+import { _getWindowSafe } from './SafeJs';
 import { StatsigClientEmitEventFunc } from './StatsigClientBase';
 import { SDK_VERSION } from './StatsigMetadata';
 import {
@@ -16,6 +16,7 @@ import {
   StatsigOptionsCommon,
 } from './StatsigOptionsCommon';
 import { UrlConfiguration } from './UrlConfiguration';
+import { _isCrossOrigin } from './UrlUtils';
 import { _isUnloading } from './VisibilityObserving';
 
 type EventSendResult = {
@@ -182,14 +183,14 @@ export class EventSender {
   }
 
   private _getRequestData(batch: EventBatch): RequestArgsWithData {
-    const headers = this._shouldIncludeEventHeaders()
+    const headers: Record<string, string> = this._shouldIncludeEventHeaders()
       ? {
           'statsig-event-count': String(batch.events.length),
           'statsig-retry-count': String(batch.attempts),
           'statsig-sdk-type': SDKType._get(this._sdkKey),
           'statsig-sdk-version': SDK_VERSION,
         }
-      : undefined;
+      : {};
 
     return {
       sdkKey: this._sdkKey,
@@ -203,7 +204,7 @@ export class EventSender {
       params: {
         [NetworkParam.EventCount]: String(batch.events.length),
       },
-      ...(headers ? { headers } : {}),
+      headers,
       credentials: 'same-origin',
     };
   }
@@ -218,13 +219,6 @@ export class EventSender {
       return true;
     }
 
-    try {
-      return (
-        new URL(this._logEventUrlConfig.getUrl(), currentOrigin).origin ===
-        currentOrigin
-      );
-    } catch {
-      return false;
-    }
+    return !_isCrossOrigin(this._logEventUrlConfig.getUrl(), currentOrigin);
   }
 }

--- a/packages/client-core/src/EventSender.ts
+++ b/packages/client-core/src/EventSender.ts
@@ -6,6 +6,7 @@ import {
   RequestArgsWithData,
   RequestFailureInfo,
 } from './NetworkCore';
+import { _getWindowSafe } from './SafeJs';
 import { SDKType } from './SDKType';
 import { StatsigClientEmitEventFunc } from './StatsigClientBase';
 import { SDK_VERSION } from './StatsigMetadata';
@@ -181,6 +182,15 @@ export class EventSender {
   }
 
   private _getRequestData(batch: EventBatch): RequestArgsWithData {
+    const headers = this._shouldIncludeEventHeaders()
+      ? {
+          'statsig-event-count': String(batch.events.length),
+          'statsig-retry-count': String(batch.attempts),
+          'statsig-sdk-type': SDKType._get(this._sdkKey),
+          'statsig-sdk-version': SDK_VERSION,
+        }
+      : undefined;
+
     return {
       sdkKey: this._sdkKey,
       data: {
@@ -193,13 +203,28 @@ export class EventSender {
       params: {
         [NetworkParam.EventCount]: String(batch.events.length),
       },
-      headers: {
-        'statsig-event-count': String(batch.events.length),
-        'statsig-retry-count': String(batch.attempts),
-        'statsig-sdk-type': SDKType._get(this._sdkKey),
-        'statsig-sdk-version': SDK_VERSION,
-      },
+      ...(headers ? { headers } : {}),
       credentials: 'same-origin',
     };
+  }
+
+  private _shouldIncludeEventHeaders(): boolean {
+    if (this._logEventUrlConfig.customUrl == null) {
+      return true;
+    }
+
+    const currentOrigin = _getWindowSafe()?.location?.origin;
+    if (!currentOrigin) {
+      return true;
+    }
+
+    try {
+      return (
+        new URL(this._logEventUrlConfig.getUrl(), currentOrigin).origin ===
+        currentOrigin
+      );
+    } catch {
+      return false;
+    }
   }
 }

--- a/packages/client-core/src/NetworkCore.ts
+++ b/packages/client-core/src/NetworkCore.ts
@@ -28,6 +28,7 @@ import {
 } from './StatsigOptionsCommon';
 import { Flatten } from './TypingUtils';
 import { UrlConfiguration } from './UrlConfiguration';
+import { _isCrossOrigin } from './UrlUtils';
 import { _isUnloading } from './VisibilityObserving';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -661,20 +662,6 @@ function _getNoResponseDiagnostics(
       hasCustomUrl: String(hasCustomUrl),
     },
   };
-}
-
-function _isCrossOrigin(
-  url: string,
-  currentOrigin: string | undefined,
-): boolean {
-  if (!currentOrigin) {
-    return true;
-  }
-  return (
-    !url.startsWith(`${currentOrigin}/`) &&
-    !url.startsWith(`${currentOrigin}?`) &&
-    url !== currentOrigin
-  );
 }
 
 function _getBodySize(body: BodyInit | undefined): number {

--- a/packages/client-core/src/UrlUtils.ts
+++ b/packages/client-core/src/UrlUtils.ts
@@ -1,0 +1,14 @@
+export function _isCrossOrigin(
+  url: string,
+  currentOrigin: string | undefined,
+): boolean {
+  if (!currentOrigin) {
+    return true;
+  }
+
+  try {
+    return new URL(url, currentOrigin).origin !== currentOrigin;
+  } catch {
+    return true;
+  }
+}

--- a/packages/client-core/src/__tests__/EventSender.test.ts
+++ b/packages/client-core/src/__tests__/EventSender.test.ts
@@ -687,7 +687,7 @@ describe('EventSender', () => {
           );
         });
 
-        it('should not include custom headers for cross-origin custom log event urls', async () => {
+        it('should send empty headers for cross-origin custom log event urls', async () => {
           setWindowOrigin('https://local.kraken.zone:4200');
 
           const customUrlConfig = new UrlConfiguration(
@@ -713,11 +713,9 @@ describe('EventSender', () => {
               params: {
                 [NetworkParam.EventCount]: '3',
               },
+              headers: {},
             }),
             expect.any(Object),
-          );
-          expect(mockNetwork.post.mock.calls[0]?.[0]).not.toHaveProperty(
-            'headers',
           );
         });
 

--- a/packages/client-core/src/__tests__/EventSender.test.ts
+++ b/packages/client-core/src/__tests__/EventSender.test.ts
@@ -19,6 +19,7 @@ describe('EventSender', () => {
   let mockEmitter: jest.MockedFunction<StatsigClientEmitEventFunc>;
   let mockUrlConfig: UrlConfiguration;
   let eventSender: EventSender;
+  const originalWindow = (global as any).window;
 
   const SDK_KEY = 'test-sdk-key';
   const TEST_OPTIONS = { networkConfig: {} };
@@ -36,6 +37,17 @@ describe('EventSender', () => {
       createMockEvent(`test-event-${i}`),
     );
     return new EventBatch(events);
+  };
+
+  const setWindowOrigin = (origin: string) => {
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      value: {
+        location: {
+          origin,
+        },
+      },
+    });
   };
 
   beforeEach(() => {
@@ -62,6 +74,13 @@ describe('EventSender', () => {
       mockUrlConfig,
       TEST_OPTIONS,
     );
+  });
+
+  afterEach(() => {
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      value: originalWindow,
+    });
   });
 
   describe('constructor', () => {
@@ -660,6 +679,106 @@ describe('EventSender', () => {
               headers: {
                 'statsig-event-count': '100',
                 'statsig-retry-count': '3',
+                'statsig-sdk-type': SDKType._get(SDK_KEY),
+                'statsig-sdk-version': SDK_VERSION,
+              },
+            }),
+            expect.any(Object),
+          );
+        });
+
+        it('should not include custom headers for cross-origin custom log event urls', async () => {
+          setWindowOrigin('https://local.kraken.zone:4200');
+
+          const customUrlConfig = new UrlConfiguration(
+            'rgstr',
+            null,
+            'https://proxy.example.com/v1',
+            null,
+          );
+          const senderWithCustomUrl = new EventSender(
+            SDK_KEY,
+            mockNetwork,
+            mockEmitter,
+            customUrlConfig,
+            TEST_OPTIONS,
+          );
+          const batch = createMockBatch(3);
+
+          await senderWithCustomUrl.sendBatch(batch);
+
+          expect(mockNetwork.post).toHaveBeenCalledWith(
+            expect.objectContaining({
+              urlConfig: customUrlConfig,
+              params: {
+                [NetworkParam.EventCount]: '3',
+              },
+            }),
+            expect.any(Object),
+          );
+          expect(mockNetwork.post.mock.calls[0]?.[0]).not.toHaveProperty(
+            'headers',
+          );
+        });
+
+        it('should include custom headers for same-origin custom log event urls', async () => {
+          setWindowOrigin('https://local.kraken.zone:4200');
+
+          const customUrlConfig = new UrlConfiguration(
+            'rgstr',
+            null,
+            'https://local.kraken.zone:4200/statsig/v1',
+            null,
+          );
+          const senderWithCustomUrl = new EventSender(
+            SDK_KEY,
+            mockNetwork,
+            mockEmitter,
+            customUrlConfig,
+            TEST_OPTIONS,
+          );
+          const batch = createMockBatch(3);
+
+          await senderWithCustomUrl.sendBatch(batch);
+
+          expect(mockNetwork.post).toHaveBeenCalledWith(
+            expect.objectContaining({
+              headers: {
+                'statsig-event-count': '3',
+                'statsig-retry-count': '0',
+                'statsig-sdk-type': SDKType._get(SDK_KEY),
+                'statsig-sdk-version': SDK_VERSION,
+              },
+            }),
+            expect.any(Object),
+          );
+        });
+
+        it('should include custom headers for relative custom log event urls', async () => {
+          setWindowOrigin('https://local.kraken.zone:4200');
+
+          const customUrlConfig = new UrlConfiguration(
+            'rgstr',
+            '/statsig/v1/rgstr',
+            null,
+            null,
+          );
+          const senderWithCustomUrl = new EventSender(
+            SDK_KEY,
+            mockNetwork,
+            mockEmitter,
+            customUrlConfig,
+            TEST_OPTIONS,
+          );
+          const batch = createMockBatch(3);
+
+          await senderWithCustomUrl.sendBatch(batch);
+
+          expect(mockNetwork.post).toHaveBeenCalledWith(
+            expect.objectContaining({
+              headers: {
+                'statsig-event-count': '3',
+                'statsig-retry-count': '0',
                 'statsig-sdk-type': SDKType._get(SDK_KEY),
                 'statsig-sdk-version': SDK_VERSION,
               },


### PR DESCRIPTION
## Summary

- omit Statsig event-count/retry/sdk headers for cross-origin custom log event URLs
- preserve existing headers for default, absolute same-origin, and relative same-origin event logging URLs
- keep the `ec` query param so event count remains available without forcing browser preflight

## Why

Custom event headers force browser CORS preflight for cross-origin log-event proxy endpoints. Managed/custom API proxy deployments can fail `/v1/rgstr` when those headers are not allowed, even though the same request works without the custom headers.

## Test plan

- `NX_DAEMON=false corepack pnpm nx test client-core --testFile=EventSender.test.ts`
- `NX_DAEMON=false corepack pnpm nx test client-core`
- `NX_DAEMON=false corepack pnpm nx build client-core`
- `NX_DAEMON=false corepack pnpm nx lint client-core`
- pre-push affected lint