### PR TITLE
S2SDK-93: Honor keepRollingWindow with autoStartRecording

### DIFF
--- a/packages/session-replay/src/TriggeredSessionReplay.ts
+++ b/packages/session-replay/src/TriggeredSessionReplay.ts
@@ -308,23 +308,24 @@ export class TriggeredSessionReplay extends SessionReplayBase {
     const keepRollingWindow =
       (this._options as TriggeredSessionReplayOptions | undefined)
         ?.keepRollingWindow === true;
+    const preserveRollingBuffer = keepRollingWindow && !this._isActiveRecording;
 
     if (values?.recording_blocked === true) {
-      if (!keepRollingWindow) {
+      if (!preserveRollingBuffer) {
         this._shutdown();
       }
       return;
     }
 
     if (!force && values?.can_record_session !== true) {
-      if (!keepRollingWindow) {
+      if (!preserveRollingBuffer) {
         this._shutdown();
       }
       return;
     }
 
     if (values?.passes_session_recording_targeting === false) {
-      if (!keepRollingWindow) {
+      if (!preserveRollingBuffer) {
         this._shutdown();
       }
       return;

--- a/packages/session-replay/src/TriggeredSessionReplay.ts
+++ b/packages/session-replay/src/TriggeredSessionReplay.ts
@@ -61,10 +61,11 @@ export class TriggeredSessionReplay extends SessionReplayBase {
   ) {
     super(client, options);
     this._subscribeToClientEvents(options);
+    if (options?.keepRollingWindow) {
+      this._attemptToStartRollingWindow();
+    }
     if (options?.autoStartRecording) {
       this._attemptToStartRecording(this._options?.forceRecording);
-    } else if (options?.keepRollingWindow) {
-      this._attemptToStartRollingWindow();
     }
   }
 
@@ -82,10 +83,11 @@ export class TriggeredSessionReplay extends SessionReplayBase {
   ): void {
     this._client.$on('values_updated', () => {
       if (!this._wasStopped) {
+        if (options?.keepRollingWindow) {
+          this._attemptToStartRollingWindow();
+        }
         if (options?.autoStartRecording) {
           this._attemptToStartRecording(this._options?.forceRecording);
-        } else if (options?.keepRollingWindow) {
-          this._attemptToStartRollingWindow();
         }
       }
     });
@@ -303,19 +305,28 @@ export class TriggeredSessionReplay extends SessionReplayBase {
       return;
     }
     const values = this._client.getContextHandle().values;
+    const keepRollingWindow =
+      (this._options as TriggeredSessionReplayOptions | undefined)
+        ?.keepRollingWindow === true;
 
     if (values?.recording_blocked === true) {
-      this._shutdown();
+      if (!keepRollingWindow) {
+        this._shutdown();
+      }
       return;
     }
 
     if (!force && values?.can_record_session !== true) {
-      this._shutdown();
+      if (!keepRollingWindow) {
+        this._shutdown();
+      }
       return;
     }
 
     if (values?.passes_session_recording_targeting === false) {
-      this._shutdown();
+      if (!keepRollingWindow) {
+        this._shutdown();
+      }
       return;
     }
 

--- a/packages/session-replay/src/__tests__/TriggeredSessionReplay/TriggeredSessionReplayRollingWindowWithAutoStart.test.ts
+++ b/packages/session-replay/src/__tests__/TriggeredSessionReplay/TriggeredSessionReplayRollingWindowWithAutoStart.test.ts
@@ -2,6 +2,8 @@ import { MockRemoteServerEvalClient } from 'statsig-test-helpers';
 
 import {
   PrecomputedEvaluationsInterface,
+  StatsigClientEventCallback,
+  StatsigClientEventName,
   StatsigMetadataProvider,
 } from '@statsig/client-core';
 
@@ -10,10 +12,19 @@ import { mockClientContext } from '../../testUtils/mockClientContext';
 
 describe('Triggered Session Replay With Rolling Window And Auto Start', () => {
   let client: jest.MockedObject<PrecomputedEvaluationsInterface>;
+  let valuesUpdatedListener: StatsigClientEventCallback<StatsigClientEventName>;
 
   beforeEach(() => {
     client = MockRemoteServerEvalClient.create();
     client.flush.mockResolvedValue();
+    client.$on.mockImplementation((name, listener) => {
+      if (name === 'values_updated') {
+        valuesUpdatedListener = listener;
+      }
+      if (name === 'logs_flushed') {
+        listener({ name: 'logs_flushed', events: [] });
+      }
+    });
     StatsigMetadataProvider.add({ isRecordingSession: undefined });
   });
 
@@ -47,5 +58,57 @@ describe('Triggered Session Replay With Rolling Window And Auto Start', () => {
     const metadata = StatsigMetadataProvider.get() as any;
     expect(metadata.isRecordingSession).toBe('true');
     expect(sessionReplay.isRecording()).toBe(true);
+  });
+
+  it('auto starts recording after values_updated enables sampling', () => {
+    const { handle } = mockClientContext(client, {
+      session_recording_rate: 1,
+      can_record_session: false,
+      passes_session_recording_targeting: true,
+    });
+    new TriggeredSessionReplay(client, {
+      autoStartRecording: true,
+      keepRollingWindow: true,
+    });
+
+    let metadata = StatsigMetadataProvider.get() as any;
+    expect(metadata.isRecordingSession).toBe(undefined);
+
+    handle.values = {
+      session_recording_rate: 1,
+      can_record_session: true,
+      passes_session_recording_targeting: true,
+    };
+    valuesUpdatedListener({ name: 'values_updated' } as any);
+
+    metadata = StatsigMetadataProvider.get() as any;
+    expect(metadata.isRecordingSession).toBe('true');
+  });
+
+  it('stops active recording when recording becomes blocked', () => {
+    const { handle } = mockClientContext(client, {
+      session_recording_rate: 1,
+      can_record_session: true,
+      passes_session_recording_targeting: true,
+    });
+    const sessionReplay = new TriggeredSessionReplay(client, {
+      autoStartRecording: true,
+      keepRollingWindow: true,
+    });
+
+    let metadata = StatsigMetadataProvider.get() as any;
+    expect(metadata.isRecordingSession).toBe('true');
+
+    handle.values = {
+      session_recording_rate: 1,
+      can_record_session: true,
+      passes_session_recording_targeting: true,
+      recording_blocked: true,
+    };
+    valuesUpdatedListener({ name: 'values_updated' } as any);
+
+    metadata = StatsigMetadataProvider.get() as any;
+    expect(metadata.isRecordingSession).toBe('false');
+    expect(sessionReplay.isRecording()).toBe(false);
   });
 });

--- a/packages/session-replay/src/__tests__/TriggeredSessionReplay/TriggeredSessionReplayRollingWindowWithAutoStart.test.ts
+++ b/packages/session-replay/src/__tests__/TriggeredSessionReplay/TriggeredSessionReplayRollingWindowWithAutoStart.test.ts
@@ -1,0 +1,51 @@
+import { MockRemoteServerEvalClient } from 'statsig-test-helpers';
+
+import {
+  PrecomputedEvaluationsInterface,
+  StatsigMetadataProvider,
+} from '@statsig/client-core';
+
+import { TriggeredSessionReplay } from '../../TriggeredSessionReplay';
+import { mockClientContext } from '../../testUtils/mockClientContext';
+
+describe('Triggered Session Replay With Rolling Window And Auto Start', () => {
+  let client: jest.MockedObject<PrecomputedEvaluationsInterface>;
+
+  beforeEach(() => {
+    client = MockRemoteServerEvalClient.create();
+    client.flush.mockResolvedValue();
+    StatsigMetadataProvider.add({ isRecordingSession: undefined });
+  });
+
+  it('keeps rolling window when auto start cannot record', () => {
+    mockClientContext(client, {
+      session_recording_rate: 1,
+      can_record_session: false,
+      passes_session_recording_targeting: true,
+    });
+    const sessionReplay = new TriggeredSessionReplay(client, {
+      autoStartRecording: true,
+      keepRollingWindow: true,
+    });
+
+    const metadata = StatsigMetadataProvider.get() as any;
+    expect(metadata.isRecordingSession).toBe(undefined);
+    expect(sessionReplay.isRecording()).toBe(true);
+  });
+
+  it('auto starts recording when sampled while keeping rolling window enabled', () => {
+    mockClientContext(client, {
+      session_recording_rate: 1,
+      can_record_session: true,
+      passes_session_recording_targeting: true,
+    });
+    const sessionReplay = new TriggeredSessionReplay(client, {
+      autoStartRecording: true,
+      keepRollingWindow: true,
+    });
+
+    const metadata = StatsigMetadataProvider.get() as any;
+    expect(metadata.isRecordingSession).toBe('true');
+    expect(sessionReplay.isRecording()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `TriggeredSessionReplay` so `keepRollingWindow` and `autoStartRecording` can be enabled together instead of auto-start taking exclusive precedence.
- Avoid shutting down the rolling buffer when auto-start is ineligible (`can_record_session`, `recording_blocked`, or failed targeting) while `keepRollingWindow` is enabled.
- Verified with `pnpm nx test session-replay` (51 tests).

Linear: https://linear.app/amplitude/issue/S2SDK-93/rolling-window-ignored-with-autostartrecording-in-session-replay

Made with [Cursor](https://cursor.com)